### PR TITLE
履歴のメッセージと並び順の変更

### DIFF
--- a/app/controllers/contents_controller.rb
+++ b/app/controllers/contents_controller.rb
@@ -27,7 +27,7 @@ class ContentsController < ApplicationController
     @comments = Comment.all
     @comment = Comment.new
     @spoiler = Spoiler.find_by(user_id: current_user.id)
-    @histories = History.where(content_id: @content.id)
+    @histories = History.where(content_id: @content.id).order(created_at: :desc)
   end
 
   def edit
@@ -49,7 +49,7 @@ class ContentsController < ApplicationController
     creator_list = params[:content_form][:creator_name].split(' ')
     if @content_form.valid?
       @content_form.update(content_update_params, @content, genre_list, creator_list)
-      History.create_log(params[:id], current_user.id, "#{@content.title}を編集しました")
+      History.create_log(params[:id], current_user.id, "編集ユーザー:")
       redirect_to content_path(params[:id])
     else
       render :edit

--- a/app/models/history.rb
+++ b/app/models/history.rb
@@ -11,7 +11,7 @@ class History < ApplicationRecord
   class << self
     def create_log(content_id, user_id, message)
       @user = User.find(user_id)
-      History.create(content_id: content_id, user_id: user_id, message: "#{@user.nickname}が#{message}")
+      History.create(content_id: content_id, user_id: user_id, message: "#{message}#{@user.nickname}")
     end
   end
 end


### PR DESCRIPTION
# What
履歴のメッセージと並び順の変更
# Why
バリデーションを変更したことで、タイトルを編集して更新されなかった場合、更新しようとしたタイトルでメッセージが保存されてしまうため。
並びが古い順だったので、最新順にして、最近更新したユーザーが分かるようにする為