### PR TITLE
操作前の確認メッセージの実装

### DIFF
--- a/app/controllers/contents_controller.rb
+++ b/app/controllers/contents_controller.rb
@@ -49,7 +49,7 @@ class ContentsController < ApplicationController
     creator_list = params[:content_form][:creator_name].split(' ')
     if @content_form.valid?
       @content_form.update(content_update_params, @content, genre_list, creator_list)
-      History.create_log(params[:id], current_user.id, "編集ユーザー:")
+      History.create_log(params[:id], current_user.id, '編集ユーザー:')
       redirect_to content_path(params[:id])
     else
       render :edit

--- a/app/javascript/message.js
+++ b/app/javascript/message.js
@@ -1,12 +1,15 @@
 function message () {
-  console.log('www')
   const moveEditBtn = document.getElementById("content-edit-btn");
   moveEditBtn.addEventListener('click', (e) => {
-    console.log('kkk')
-    e.preventDefault();
-    e.returnValue = "hokano"
+    const select_message = confirm("編集画面では作品の情報が全て見えてしまいます\n移動して編集しますか？");
+
+    if (select_message) {
+      console.log('idousimasita')
+    } else {
+      console.log('yameta')
+      e.preventDefault()
+    };
   });
 };
-
 
 window.addEventListener('load', message);

--- a/app/javascript/message.js
+++ b/app/javascript/message.js
@@ -1,0 +1,12 @@
+function message () {
+  console.log('www')
+  const moveEditBtn = document.getElementById("content-edit-btn");
+  moveEditBtn.addEventListener('click', (e) => {
+    console.log('kkk')
+    e.preventDefault();
+    e.returnValue = "hokano"
+  });
+};
+
+
+window.addEventListener('load', message);

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -10,6 +10,7 @@ require("channels")
 require("../content_lists.js")
 require("../genre.js")
 require("../creator.js")
+require("../message.js")
 
 // Uncomment to copy all static images under ../images to the output folder and reference
 // them with the image_pack_tag helper in views (e.g <%= image_pack_tag 'rails.png' %>)

--- a/app/views/contents/show.html.erb
+++ b/app/views/contents/show.html.erb
@@ -64,7 +64,7 @@
 
     <div>
       <% if user_signed_in? %>
-        <%= link_to "作品の情報を編集する", edit_content_path(params[:id]), class:"content-edit-btn" %>
+        <%= link_to "作品の情報を編集する", edit_content_path(params[:id]), class:"content-edit-btn", id:"content-edit-btn" %>
       <% end %>
     </div>
 


### PR DESCRIPTION
# What
編集ページ移動前の確認メッセージを実装
# Why
ネタバレ防止を選択していても、編集画面では情報が全て見えてしまうので、注意喚起の為